### PR TITLE
Fix text transform to preserve case in code

### DIFF
--- a/css/theme/lofman.css
+++ b/css/theme/lofman.css
@@ -147,7 +147,7 @@ body {
 .reveal code,
 .reveal pre {
   font-family: "Source Code Pro", monospace;
-  text-transform: lowercase;
+  text-transform: none;
   background: rgba(0,0,0,0.0392);
   border-radius: 0.08em;
   padding: 0.05em 0.1em; }


### PR DESCRIPTION
Remove the `text-transform: lowercase`  on the `.reveal code` selector and replace with `text-transform: none` so the text will respect the case of the original code, so that anyone that copies case sensitive code will copy the proper case.